### PR TITLE
Fix error in web.config comments

### DIFF
--- a/web.config
+++ b/web.config
@@ -11,7 +11,7 @@
     <!-- Visit http://blogs.msdn.com/b/windowsazure/archive/2013/11/14/introduction-to-websockets-on-windows-azure-web-sites.aspx for more information on WebSocket support -->
     <webSocket enabled="false" />
     <handlers>
-      <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+      <!-- Indicates that the index.js file is a node.js site to be handled by the iisnode module -->
       <add name="iisnode" path="index.js" verb="*" modules="iisnode"/>
     </handlers>
     <rewrite>


### PR DESCRIPTION
A comment in web.config refers to the (non-existent) file server.js instead of the correct file in this context (index.js).